### PR TITLE
Fixes for iot-lora-configure

### DIFF
--- a/iot-lora-configure
+++ b/iot-lora-configure
@@ -2,7 +2,6 @@
 # IOT LoRa Gateway Configuration Script,
 # Setup Dialog Box
 from dialog import Dialog
-import getpass
 import shutil
 import codecs
 import json
@@ -14,24 +13,22 @@ import pprint
 d = Dialog(dialog="dialog")
 d.set_background_title("IOT LoRa Gateway Configurator")
 
-if getpass.getuser() != "root":
-    d.msgbox("This installer must be ran as root, please sudo to "
+if os.geteuid() != 0:
+    d.msgbox("This installer must be run as root, please sudo to "
              "root and try again.")
+    os.system("clear")
     sys.exit(1)
 
 d.msgbox("This installer script will ask you questions to setup your gateway."
-         "\r\n \r\n At the same time on another device you will require to "
-         "have already signed up to an account with The Things Network and "
-         "created a gateway to fill out this script.", height=20, width=80)
+         "\r\n\r\nYou need to have already signed up for an account with "
+         "The Things Network and created a gateway to fill out this script.", height=10, width=80)
 
-#Open the configuration as old data so we can populate if the user has already
+# Open the configuration as old data so we can populate if the user has already
 # entered data
 configLocation = '/boot/iotloragateway/local_conf.json'
 
 
-##Check if there's a configuration file already, if not copy it to the correct directory ready for the configuration script.
-
-
+# Check if there's a configuration file already, if not copy it to the correct directory ready for the configuration script.
 try:
     with open(configLocation, 'r') as f:
         olddata = json.load(f)
@@ -41,39 +38,44 @@ except FileNotFoundError:
         with open(configLocation, 'r') as f:
             olddata = json.load(f)
     except:
-        print("Config File Error"
+        os.system("clear")
+        print("Config File Error")
         exit()
 
-
-#Get the name
-if(olddata["gateway_conf"]["servers"][0]["serv_gw_id"] !=
-"<gateway name from console>"):
-    gatewayIdDetails = d.inputbox("Please enter the Gateway ID that you setup "
-                                  "with The Things Network",
-                init=olddata["gateway_conf"]["servers"][0]["serv_gw_id"])
+# Get the name
+if olddata["gateway_conf"]["servers"][0]["serv_gw_id"] != "<gateway name from console>":
+    init = olddata["gateway_conf"]["servers"][0]["serv_gw_id"]
 else:
-    gatewayIdDetails = d.inputbox("Please enter the Gateway ID that you setup "
-                                  "with The Things Network")
-#Get the description
-if(olddata["gateway_conf"]["description"] !=
-"CHANGE-ME"):
-    descriptionDetails = d.inputbox("Please enter a short description of the "
-                                    "gateway.",
-                  init=olddata["gateway_conf"]["description"])
+    init = ""
+gatewayIdDetails = d.inputbox("Please enter the Gateway ID that you setup "
+                              "with The Things Network", init=init, width=40)
+if gatewayIdDetails[0] == "cancel":
+    os.system("clear")
+    sys.exit(1)
+
+# Get the description
+if olddata["gateway_conf"]["description"] != "CHANGE-ME":
+    init = olddata["gateway_conf"]["description"]
 else:
-    descriptionDetails = d.inputbox("Please enter a short description of the "
-                                    "gateway.")
+    init = ""
+descriptionDetails = d.inputbox("Please enter a short description of the gateway.",
+                                init=init, width=40)
+if descriptionDetails[0] == "cancel":
+    os.system("clear")
+    sys.exit(1)
 
-#Get the users email address
-if(olddata["gateway_conf"]["contact_email"] !=
-"CHANGE-ME"):
-    emailDetails = d.inputbox("Please enter a contact email address",
-init=olddata["gateway_conf"]["contact_email"])
+# Get the users email address
+if olddata["gateway_conf"]["contact_email"] != "CHANGE-ME":
+    init = olddata["gateway_conf"]["contact_email"]
 else:
-    emailDetails = d.inputbox("Please enter a contact email address")
+    init = ""
+emailDetails = d.inputbox("Please enter a contact email address",
+                          init=init, width=40)
+if emailDetails[0] == "cancel":
+    os.system("clear")
+    sys.exit(1)
 
-
-# Get The Frequency
+# Get the frequency
 frequencyDetails = d.menu("Please select the frequency of your gateway:",
                           choices=[("Europe", "868MHz"),
                                    ("Asia 1", "920-923MHz"),
@@ -84,6 +86,10 @@ frequencyDetails = d.menu("Please select the frequency of your gateway:",
                                    ("Korea", "920-923MHz"),
                                    ("United States", "915Mhz")
                                    ])
+if frequencyDetails[0] == "cancel":
+    os.system("clear")
+    sys.exit(1) 
+
 # Get the Server
 serverDetails = d.menu("Please select the bridge for your gateway",
                        choices=[("Europe", "ttn-router-eu"),
@@ -96,28 +102,43 @@ serverDetails = d.menu("Please select the bridge for your gateway",
                                 ("Japan", "ttn-router-jp"),
                                 ("US West", "ttn-router-us-west")
                                 ])
+if serverDetails[0] == "cancel":
+    os.system("clear")
+    sys.exit(1) 
 
-#Get the users location
-locationDetails = d.form("Location", [("Latitude", 1, 1, "", 1, 15, 12, 12),
-                                      ("Longitude", 3, 1, "", 3, 15, 12, 12),
-                                      ("Altitude", 5, 1, "", 5, 15, 5, 5)])
-
-#Messagebox
-if(olddata["gateway_conf"]["servers"][0]["serv_gw_key"] !=
-"<gateway secret key from console>"):
-    response = d.msgbox("Do you wish to update your TTN Key?",
-             height=20, width=80)
-    print(response)
-    input()
+# Get the users location
+if (olddata["gateway_conf"]["ref_latitude"] == 0 and
+    olddata["gateway conf"]["ref_longitude"] == 0 and
+    olddata["gateway_conf"]["ref_altitude"] == 0):
+    elements = ("", "", "")
 else:
-    d.msgbox("The configuration script will now ask you for your TTN Key from "
-             "the console. Please paste it in and then press enter.",
-             height=20, width=80)
-    keyDetails = input("TTN Console Key: ")
+    elements = (olddata["gateway_conf"]["ref_latitude"],
+                olddata["gateway_conf"]["ref_longitude"],
+                olddata["gateway_conf"]["ref_altitude"])
+locationDetails = d.form("Location", [("Latitude",  1, 1, elements[0], 1, 15, 13, 13),
+                                      ("Longitude", 3, 1, elements[1], 3, 15, 13, 13),
+                                      ("Altitude",  5, 1, elements[2], 5, 15,  5,  5)])
+if locationDetails[0] == "cancel":
+    os.system("clear")
+    sys.exit(1)
 
+# The Things Network gateway key
+response = "ok"
+init = ""
+if olddata["gateway_conf"]["servers"][0]["serv_gw_key"] != "<gateway secret key from console>":
+    response = d.yesno("Do you wish to update your TTN Key?", height=6, width=40)
+    init = olddata["gateway_conf"]["servers"][0]["serv_gw_key"]
+if response == "ok":
+    keyDetails = d.inputbox("Enter TTN gateway key:", init=init, height=10, width=80)
+    if keyDetails[0] == "cancel":
+        os.system("clear")
+        sys.exit(1)
+else:
+    keyDetails = ("ok", olddata["gateway_conf"]["servers"][0]["serv_gw_key"])
+    
 d.msgbox("The configuration script will now configure the packet forwarder, "
          "enable SPI and confirm SSH is enabled for remote management.",
-         height=20, width=80)
+         height=10, width=80)
 
 # Now lets set the arrays with each of the pins and servers and such
 freqList = [
@@ -140,7 +161,6 @@ serverList = [
     ["Japan", "router.thethingsnetwork.jp"],
     ["US West", "router.us.thethings.network"]
 ]
-
 
 freqDict = dict(freqList)
 serverDict = dict(serverList)
@@ -166,7 +186,7 @@ with open(configLocation, 'r') as f:
     data["gateway_conf"]["ref_latitude"] = locationDetails[1][0]
     data["gateway_conf"]["ref_longitude"] = locationDetails[1][1]
     data["gateway_conf"]["ref_altitude"] = locationDetails[1][2]
-    data["gateway_conf"]["servers"][0]["serv_gw_key"] = keyDetails
+    data["gateway_conf"]["servers"][0]["serv_gw_key"] = keyDetails[1]
     data["gateway_conf"]["gateway_ID"] = gatewayGenId.decode()
     data["gateway_conf"]["servers"][0]["server_address"] = server_address
 
@@ -177,9 +197,16 @@ with open(configLocation, 'w') as f:
 # Copy the frequency plan over
 boot_conf_file = "/boot/iotloragateway/global_conf.json"
 shutil.copyfile(freqDict[frequencyDetails[1]], boot_conf_file)
+
+# Set execute bit on iot-lora-gateway-reset.sh
 st = os.stat("/opt/iotloragateway/iot-lora-gateway-reset.sh")
 os.chmod("/opt/iotloragateway/iot-lora-gateway-reset.sh", st.st_mode | 0o111)
 
-restart = d.pause("The system now will reboot to finish configuring your "
-                    "gateway andautomatically start the forwarder."
-                    "if you do not want to restart select cancel.")
+# Prompt for reboot
+restart = d.pause("The system now will reboot in 10 seconds to finish "
+                  "configuring your gateway andautomatically start the "
+                  "forwarder.\r\n\r\n"
+                  "If you do not want to restart select cancel.", seconds=10)
+os.system("clear")
+if restart == "ok":
+     os.system("sudo reboot")

--- a/template_configs/iot-lora-gateway-reset.sh
+++ b/template_configs/iot-lora-gateway-reset.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-echo "22" > /sys/class/gpio/export
+if [ ! -d "/sys/class/gpio/gpio22" ]; then
+    echo "22" > /sys/class/gpio/export
+fi
 echo "out" > /sys/class/gpio/gpio22/direction
 echo "1" > /sys/class/gpio/gpio22/value
 sleep 1


### PR DESCRIPTION
Selecting cancel in iot-lora-configure dialogs now exits the program.
Improved user experience by prefilling fields when possible.
Fix iot-lora-gateway-reset.sh to avoid error/warning when gpio22 is already exported.